### PR TITLE
Add require description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ for [re-frame](https://github.com/Day8/re-frame) applications.
 ```clojure
 [re-pressed "0.2.0"]
 ```
+And in your ns:
+```clojure
+(ns your-ns
+  (:require [re-pressed.core :as rp]))
+```
 
 **Note**: For now, this library should be considered *alpha quality*, as the api is still settling.
 


### PR DESCRIPTION
I thought this little, essential nugget of README information was missing :)
Always good to make it _easy_ on folks to adopt your library.